### PR TITLE
feat: 리뷰 작성이 가능한 게시글 목록 조회 기능 추가 및 버그 수정

### DIFF
--- a/src/main/java/com/dku/council/domain/with_dankook/controller/BearEatsController.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/controller/BearEatsController.java
@@ -2,6 +2,7 @@ package com.dku.council.domain.with_dankook.controller;
 
 import com.dku.council.domain.post.model.dto.response.ResponsePage;
 import com.dku.council.domain.with_dankook.model.dto.list.SummarizedBearEatsDto;
+import com.dku.council.domain.with_dankook.model.dto.list.SummarizedBearEatsPossibleReviewDto;
 import com.dku.council.domain.with_dankook.model.dto.request.RequestCreateBearEatsDto;
 import com.dku.council.domain.with_dankook.model.dto.response.ResponseSingleBearEatsDto;
 import com.dku.council.domain.with_dankook.service.BearEatsService;
@@ -109,5 +110,19 @@ public class BearEatsController {
     @UserAuth
     public void close(AppAuthentication auth, @PathVariable Long id) {
         bearEatsService.close(id, auth.getUserId());
+    }
+
+    /**
+     * 내가 참여한 BearEats 게시글 중, 리뷰 작성이 가능한 게시글 목록 조회
+     *
+     * @param pageable 페이징 size, sort, page
+     * @return         페이징된 리뷰 작성이 가능한 BearEats 게시글 목록 조회
+     */
+    @GetMapping("/my/possible/review")
+    @UserAuth
+    public ResponsePage<SummarizedBearEatsPossibleReviewDto> listPossibleReviewPosts(AppAuthentication auth,
+                                                                                     @ParameterObject Pageable pageable) {
+        Page<SummarizedBearEatsPossibleReviewDto> list = bearEatsService.listMyPossibleReviewPosts(auth.getUserId(), pageable);
+        return new ResponsePage<>(list);
     }
 }

--- a/src/main/java/com/dku/council/domain/with_dankook/controller/BearEatsController.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/controller/BearEatsController.java
@@ -98,4 +98,16 @@ public class BearEatsController {
                        @PathVariable Long id) {
         bearEatsService.delete(id, auth.getUserId(), auth.isAdmin());
     }
+
+    /**
+     * BearEats 게시글 모집 완료 처리
+     * 유저가 처리하거나 관리자가 강제로 처리할 수 있습니다.
+     *
+     * @param id   게시글 id
+     */
+    @PatchMapping("/{id}")
+    @UserAuth
+    public void close(AppAuthentication auth, @PathVariable Long id) {
+        bearEatsService.close(id, auth.getUserId());
+    }
 }

--- a/src/main/java/com/dku/council/domain/with_dankook/controller/EatingAloneController.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/controller/EatingAloneController.java
@@ -99,4 +99,16 @@ public class EatingAloneController {
                        @PathVariable @Valid Long id) {
         eatingAloneService.delete(id, auth.getUserId(), auth.getUserRole().isAdmin());
     }
+
+    /**
+     * 단혼밥 게시글 모집 완료 처리
+     * 유저가 처리하거나 관리자가 강제로 처리할 수 있습니다.
+     *
+     * @param id   게시글 id
+     */
+    @PatchMapping("/{id}")
+    @UserAuth
+    public void close(AppAuthentication auth, @PathVariable Long id) {
+        eatingAloneService.close(id, auth.getUserId());
+    }
 }

--- a/src/main/java/com/dku/council/domain/with_dankook/controller/EatingAloneController.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/controller/EatingAloneController.java
@@ -2,6 +2,7 @@ package com.dku.council.domain.with_dankook.controller;
 
 import com.dku.council.domain.post.model.dto.response.ResponsePage;
 import com.dku.council.domain.with_dankook.model.dto.list.SummarizedEatingAloneDto;
+import com.dku.council.domain.with_dankook.model.dto.list.SummarizedEatingAlonePossibleReviewDto;
 import com.dku.council.domain.with_dankook.model.dto.request.RequestCreateEatingAloneDto;
 import com.dku.council.domain.with_dankook.model.dto.response.ResponseSingleEatingAloneDto;
 import com.dku.council.domain.with_dankook.service.EatingAloneService;
@@ -110,5 +111,19 @@ public class EatingAloneController {
     @UserAuth
     public void close(AppAuthentication auth, @PathVariable Long id) {
         eatingAloneService.close(id, auth.getUserId());
+    }
+
+    /**
+     * 내가 참여한 단혼밥 게시글 중, 리뷰 작성이 가능한 게시글 목록 조회
+     *
+     * @param pageable 페이징 size, sort, page
+     * @return         페이징된 리뷰 작성이 가능한 단혼밥 게시글 목록 조회
+     */
+    @GetMapping("/my/possible/review")
+    @UserAuth
+    public ResponsePage<SummarizedEatingAlonePossibleReviewDto> listPossibleReviewPosts(AppAuthentication auth,
+                                                                                        @ParameterObject Pageable pageable) {
+        Page<SummarizedEatingAlonePossibleReviewDto> list = eatingAloneService.listMyPossibleReviewPosts(auth.getUserId(), pageable);
+        return new ResponsePage<>(list);
     }
 }

--- a/src/main/java/com/dku/council/domain/with_dankook/controller/RoommateController.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/controller/RoommateController.java
@@ -2,6 +2,7 @@ package com.dku.council.domain.with_dankook.controller;
 
 import com.dku.council.domain.post.model.dto.response.ResponsePage;
 import com.dku.council.domain.with_dankook.model.dto.list.SummarizedRoommateDto;
+import com.dku.council.domain.with_dankook.model.dto.list.SummarizedRoommatePossibleReviewDto;
 import com.dku.council.domain.with_dankook.model.dto.request.RequestCreateRoommateDto;
 import com.dku.council.domain.with_dankook.model.dto.request.RequestCreateSurveyDto;
 import com.dku.council.domain.with_dankook.model.dto.response.ResponseSingleRoommateDto;
@@ -135,5 +136,19 @@ public class RoommateController {
     public ResponseBooleanDto isSurveyExist(AppAuthentication auth) {
         boolean result = surveyService.checkSurvey(auth.getUserId());
         return new ResponseBooleanDto(result);
+    }
+
+    /**
+     * 내가 참여한 구해줘! 룸메 게시글 중, 리뷰 작성이 가능한 게시글 목록 조회
+     *
+     * @param pageable 페이징 size, sort, page
+     * @return         페이징된 리뷰 작성이 가능한 구해줘! 룸메 게시글 목록 조회
+     */
+    @GetMapping("/my/possible/review")
+    @UserAuth
+    public ResponsePage<SummarizedRoommatePossibleReviewDto> listPossibleReviewPosts(AppAuthentication auth,
+                                                                                     @ParameterObject Pageable pageable) {
+        Page<SummarizedRoommatePossibleReviewDto> list = roommateService.listMyPossibleReviewPosts(auth.getUserId(), pageable);
+        return new ResponsePage<>(list);
     }
 }

--- a/src/main/java/com/dku/council/domain/with_dankook/controller/StudyController.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/controller/StudyController.java
@@ -2,6 +2,7 @@ package com.dku.council.domain.with_dankook.controller;
 
 import com.dku.council.domain.post.model.dto.response.ResponsePage;
 import com.dku.council.domain.with_dankook.model.dto.list.SummarizedStudyDto;
+import com.dku.council.domain.with_dankook.model.dto.list.SummarizedStudyPossibleReviewDto;
 import com.dku.council.domain.with_dankook.model.dto.request.RequestCreateStudyDto;
 import com.dku.council.domain.with_dankook.model.dto.response.ResponseSingleStudyDto;
 import com.dku.council.domain.with_dankook.service.StudyService;
@@ -126,5 +127,19 @@ public class StudyController {
     @UserAuth
     public void close(AppAuthentication auth, @PathVariable Long id) {
         studyService.close(id, auth.getUserId());
+    }
+
+    /**
+     * 내가 참여한 단터디 게시글 중, 리뷰 작성이 가능한 게시글 목록 조회
+     *
+     * @param pageable 페이징 size, sort, page
+     * @return         페이징된 리뷰 작성이 가능한 단터디 게시글 목록 조회
+     */
+    @GetMapping("/my/possible/review")
+    @UserAuth
+    public ResponsePage<SummarizedStudyPossibleReviewDto> listPossibleReviewPosts(AppAuthentication auth,
+                                                                                  @ParameterObject Pageable pageable) {
+        Page<SummarizedStudyPossibleReviewDto> list = studyService.listMyPossibleReviewPosts(auth.getUserId(), pageable);
+        return new ResponsePage<>(list);
     }
 }

--- a/src/main/java/com/dku/council/domain/with_dankook/model/dto/list/SummarizedBearEatsPossibleReviewDto.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/model/dto/list/SummarizedBearEatsPossibleReviewDto.java
@@ -1,0 +1,42 @@
+package com.dku.council.domain.with_dankook.model.dto.list;
+
+import com.dku.council.domain.with_dankook.model.dto.RecruitedUsersDto;
+import com.dku.council.domain.with_dankook.model.entity.type.BearEats;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Getter
+public class SummarizedBearEatsPossibleReviewDto {
+    @NotNull
+    @Schema(description = "게시글 id", example = "5")
+    private final Long withDankookId;
+
+    @Schema(description = "음식점 이름", example = "체리스시")
+    private final String restaurant;
+
+    @Schema(description = "배달 장소", example = "혜당관 406호")
+    private final String deliveryPlace;
+
+    @Schema(description = "배달 주문 시간", example = "2024-01-01 12:30:00")
+    private final LocalDateTime deliveryTime;
+
+    @Schema(description = "리뷰를 작성할 사용자들 리스트", example = "[1, 3, 4]")
+    private final List<RecruitedUsersDto> targetUserList;
+
+    public SummarizedBearEatsPossibleReviewDto(BearEats bearEats, Long writerId) {
+        this.withDankookId = bearEats.getId();
+        this.restaurant = bearEats.getRestaurant();
+        this.deliveryPlace = bearEats.getDeliveryPlace();
+        this.deliveryTime = bearEats.getDeliveryTime();
+        this.targetUserList = bearEats.getUsers().stream()
+                .filter(user -> !Objects.equals(user.getParticipant().getId(), writerId))
+                .map(RecruitedUsersDto::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/dku/council/domain/with_dankook/model/dto/list/SummarizedEatingAlonePossibleReviewDto.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/model/dto/list/SummarizedEatingAlonePossibleReviewDto.java
@@ -1,0 +1,37 @@
+package com.dku.council.domain.with_dankook.model.dto.list;
+
+import com.dku.council.domain.with_dankook.model.dto.RecruitedUsersDto;
+import com.dku.council.domain.with_dankook.model.entity.type.EatingAlone;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Getter
+public class SummarizedEatingAlonePossibleReviewDto {
+    @NotNull
+    @Schema(description = "게시글 id", example = "5")
+    private final Long withDankookId;
+
+    @Schema(description = "제목", example = "게시글 제목")
+    private final String title;
+
+    @Schema(description = "내용", example = "게시글 본문")
+    private final String content;
+
+    @Schema(description = "리뷰를 작성할 사용자들 리스트", example = "[1, 3, 4]")
+    private final List<RecruitedUsersDto> targetUserList;
+
+    public SummarizedEatingAlonePossibleReviewDto(EatingAlone eatingAlone, Long writerId) {
+        this.withDankookId = eatingAlone.getId();
+        this.title = eatingAlone.getTitle();
+        this.content = eatingAlone.getContent();
+        this.targetUserList = eatingAlone.getUsers().stream()
+                .filter(user -> !Objects.equals(user.getParticipant().getId(), writerId))
+                .map(RecruitedUsersDto::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/dku/council/domain/with_dankook/model/dto/list/SummarizedRoommatePossibleReviewDto.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/model/dto/list/SummarizedRoommatePossibleReviewDto.java
@@ -1,0 +1,44 @@
+package com.dku.council.domain.with_dankook.model.dto.list;
+
+import com.dku.council.domain.with_dankook.model.dto.RecruitedUsersDto;
+import com.dku.council.domain.with_dankook.model.entity.ResidenceDuration;
+import com.dku.council.domain.with_dankook.model.entity.type.Roommate;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Getter
+public class SummarizedRoommatePossibleReviewDto {
+    @NotNull
+    @Schema(description = "게시글 id", example = "5")
+    private final Long withDankookId;
+
+    @NotNull
+    @Schema(description = "제목", example = "게시글 제목")
+    private final String title;
+
+    @NotNull
+    @Schema(description = "생활관", example = "웅비홀")
+    private final String livingPlace;
+
+    @Schema(description = "기숙사 입사 기간", example = "SEMESTER")
+    private final ResidenceDuration residenceDuration;
+
+    @Schema(description = "리뷰를 작성할 사용자들 리스트", example = "[1, 3, 4]")
+    private final List<RecruitedUsersDto> targetUserList;
+
+    public SummarizedRoommatePossibleReviewDto(Roommate roommate, Long writerId) {
+        this.withDankookId = roommate.getId();
+        this.title = roommate.getTitle();
+        this.livingPlace = roommate.getLivingPlace();
+        this.residenceDuration = roommate.getResidenceDuration();
+        this.targetUserList = roommate.getUsers().stream()
+                .filter(user -> !Objects.equals(user.getParticipant().getId(), writerId))
+                .map(RecruitedUsersDto::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/dku/council/domain/with_dankook/model/dto/list/SummarizedStudyPossibleReviewDto.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/model/dto/list/SummarizedStudyPossibleReviewDto.java
@@ -1,0 +1,37 @@
+package com.dku.council.domain.with_dankook.model.dto.list;
+
+import com.dku.council.domain.with_dankook.model.dto.RecruitedUsersDto;
+import com.dku.council.domain.with_dankook.model.entity.type.Study;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Getter
+public class SummarizedStudyPossibleReviewDto {
+    @NotNull
+    @Schema(description = "게시글 id", example = "5")
+    private final Long withDankookId;
+
+    @Schema(description = "제목", example = "게시글 제목")
+    private final String title;
+
+    @Schema(description = "내용", example = "게시글 본문")
+    private final String content;
+
+    @Schema(description = "리뷰를 작성할 사용자들 리스트", example = "[1, 3, 4]")
+    private final List<RecruitedUsersDto> targetUserList;
+
+    public SummarizedStudyPossibleReviewDto(Study study, Long writerId) {
+        this.withDankookId = study.getId();
+        this.title = study.getTitle();
+        this.content = study.getContent();
+        this.targetUserList = study.getUsers().stream()
+                .filter(user -> !Objects.equals(user.getParticipant().getId(), writerId))
+                .map(RecruitedUsersDto::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/dku/council/domain/with_dankook/model/dto/request/RequestCreateSurveyDto.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/model/dto/request/RequestCreateSurveyDto.java
@@ -41,7 +41,7 @@ public class RequestCreateSurveyDto {
     private final SleepTime sleepTime;
 
     @NotNull
-    @Schema(description = "청소횟수", example = "ONCE_A_WEEK")
+    @Schema(description = "청소횟수", example = "ONCE_UNDER_WEEK")
     private final CleanUpCount cleanUpCount;
 
     @Schema(description = "기타 성향", example = "")

--- a/src/main/java/com/dku/council/domain/with_dankook/repository/WithDankookUserRepository.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/repository/WithDankookUserRepository.java
@@ -36,11 +36,13 @@ public interface WithDankookUserRepository extends JpaRepository<WithDankookUser
     Optional<WithDankookUser> findByUserIdAndWithDankookId(@Param("userId") Long userId, @Param("withDankookId") Long withDankookId);
 
     @Query("select u from WithDankookUser u " +
-            "where u.participant.id =: targetUserId and " +
-            "u.participantStatus = 'VALID' ")
-    boolean findByUserIdCheckingValid(@Param("targetUserId") Long targetUserId);
+            "where u.withDankook.id = :withDankookId and " +
+                    "u.participant.id = :targetUserId and " +
+                    "u.participantStatus = 'VALID' ")
+    Optional<WithDankookUser> findByUserIdCheckingValid(@Param("withDankookId") Long withDankookId,
+                                                        @Param("targetUserId") Long targetUserId);
 
     @Query("select u from WithDankookUser u " +
-            "where u.participant.id =: userId ")
+            "where u.participant.id = :userId ")
     Optional<WithDankookUser> findByParticipantId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/dku/council/domain/with_dankook/repository/with_dankook/BearEatsRepository.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/repository/with_dankook/BearEatsRepository.java
@@ -11,4 +11,13 @@ public interface BearEatsRepository extends WithDankookRepository<BearEats>{
     @Query("select b from BearEats b where b.masterUser.id = :userId and " +
             "(b.withDankookStatus='ACTIVE' or b.withDankookStatus='CLOSED') ")
     Page<BearEats> findAllBearEatsByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("select b from BearEats b " +
+            "join WithDankookUser u " +
+            "on b.id = u.withDankook.id " +
+            "where u.participant.id = :userId and u.reviewStatus = false and " +
+            "((b.withDankookStatus in ('FULL', 'CLOSED')) or (b.withDankookStatus = 'ACTIVE' and b.deliveryTime <= CURRENT_TIMESTAMP)) " +
+            "order by b.lastModifiedAt DESC ")
+    Page<BearEats> findAllPossibleReviewPost(@Param("userId") Long userId,
+                                          Pageable pageable);
 }

--- a/src/main/java/com/dku/council/domain/with_dankook/repository/with_dankook/EatingAloneRepository.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/repository/with_dankook/EatingAloneRepository.java
@@ -10,4 +10,13 @@ public interface EatingAloneRepository extends WithDankookRepository<EatingAlone
     @Query("select e from EatingAlone e where e.masterUser.id = :userId and " +
             "(e.withDankookStatus='ACTIVE' or e.withDankookStatus='CLOSED') ")
     Page<EatingAlone> findAllEatingAloneByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("select e from EatingAlone e " +
+            "join WithDankookUser u " +
+            "on e.id = u.withDankook.id " +
+            "where u.participant.id = :userId and u.reviewStatus = false and " +
+            "(e.withDankookStatus in ('FULL', 'CLOSED')) " +
+            "order by e.lastModifiedAt DESC ")
+    Page<EatingAlone> findAllPossibleReviewPost(@Param("userId") Long userId,
+                                          Pageable pageable);
 }

--- a/src/main/java/com/dku/council/domain/with_dankook/repository/with_dankook/RoommateRepository.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/repository/with_dankook/RoommateRepository.java
@@ -20,4 +20,13 @@ public interface RoommateRepository extends WithDankookRepository<Roommate>{
             "where r.masterUser.id = :userId and " +
             "(r.withDankookStatus != 'DELETED' or r.withDankookStatus != 'DELETED_BY_ADMIN') ")
     Optional<Roommate> findByUserId(@Param("userId") Long userId);
+
+    @Query("select r from Roommate r " +
+            "join WithDankookUser u " +
+            "on r.id = u.withDankook.id " +
+            "where u.participant.id = :userId and u.reviewStatus = false and " +
+            "(r.withDankookStatus = 'CLOSED') " +
+            "order by r.lastModifiedAt DESC ")
+    Page<Roommate> findAllPossibleReviewPost(@Param("userId") Long userId,
+                                          Pageable pageable);
 }

--- a/src/main/java/com/dku/council/domain/with_dankook/repository/with_dankook/StudyRepository.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/repository/with_dankook/StudyRepository.java
@@ -11,4 +11,13 @@ public interface StudyRepository extends WithDankookRepository<Study>{
     @Query("select s from Study s where s.masterUser.id = :userId and " +
             "(s.withDankookStatus='ACTIVE' or s.withDankookStatus='CLOSED') ")
     Page<Study> findAllStudyByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("select s from Study s " +
+            "join WithDankookUser u " +
+            "on s.id = u.withDankook.id " +
+            "where u.participant.id = :userId and u.reviewStatus = false and " +
+            "((s.withDankookStatus in ('FULL', 'CLOSED')) or (s.withDankookStatus = 'ACTIVE' and s.endTime <= CURRENT_TIMESTAMP)) " +
+            "order by s.lastModifiedAt DESC ")
+    Page<Study> findAllPossibleReviewPost(@Param("userId") Long userId,
+                                          Pageable pageable);
 }

--- a/src/main/java/com/dku/council/domain/with_dankook/repository/with_dankook/WithDankookRepository.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/repository/with_dankook/WithDankookRepository.java
@@ -61,5 +61,10 @@ public interface WithDankookRepository<T extends WithDankook> extends JpaReposit
     @Query(value = "select COUNT(*) from with_dankook w " +
             "where w.with_dankook_id = :withDankookId and " +
             "((w.with_dankook_status in ('FULL', 'CLOSED')) or (w.with_dankook_status = 'ACTIVE' and w.end_time <= CURRENT_TIMESTAMP())) ", nativeQuery = true)
-    int findWithClosedOrFullOrActiveByIdToCreateReview(@Param("withDankookId") Long withDankookId);
+    int findWithClosedOrFullOrActiveEndTimeByIdToCreateReview(@Param("withDankookId") Long withDankookId);
+
+    @Query(value = "select COUNT(*) from with_dankook w " +
+            "where w.with_dankook_id = :withDankookId and " +
+            "((w.with_dankook_status in ('FULL', 'CLOSED')) or (w.with_dankook_status = 'ACTIVE' and w.delivery_time <= CURRENT_TIMESTAMP())) ", nativeQuery = true)
+    int findWithClosedOrFullOrActiveDeliveryTimeByIdToCreateReview(@Param("withDankookId") Long withDankookId);
 }

--- a/src/main/java/com/dku/council/domain/with_dankook/service/BearEatsService.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/service/BearEatsService.java
@@ -13,6 +13,7 @@ import com.dku.council.domain.with_dankook.model.entity.type.BearEats;
 import com.dku.council.domain.with_dankook.repository.with_dankook.BearEatsRepository;
 import com.dku.council.domain.with_dankook.repository.WithDankookUserRepository;
 import com.dku.council.global.auth.role.UserRole;
+import com.dku.council.global.error.exception.NotGrantedException;
 import com.dku.council.global.error.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -105,4 +106,14 @@ public class BearEatsService {
         withDankookService.delete(bearEatsRepository, id, userId, isAdmin);
     }
 
+    @Transactional
+    public void close(Long tradeId, Long userId) {
+        bearEatsRepository.findById(tradeId).ifPresent(eatingAlone -> {
+            if (eatingAlone.getMasterUser().getId().equals(userId)) {
+                eatingAlone.close();
+            } else{
+                throw new NotGrantedException();
+            }
+        });
+    }
 }

--- a/src/main/java/com/dku/council/domain/with_dankook/service/EatingAloneService.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/service/EatingAloneService.java
@@ -13,6 +13,7 @@ import com.dku.council.domain.with_dankook.model.entity.type.EatingAlone;
 import com.dku.council.domain.with_dankook.repository.with_dankook.EatingAloneRepository;
 import com.dku.council.domain.with_dankook.repository.WithDankookUserRepository;
 import com.dku.council.global.auth.role.UserRole;
+import com.dku.council.global.error.exception.NotGrantedException;
 import com.dku.council.global.error.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -104,5 +105,16 @@ public class EatingAloneService {
     @Transactional
     public void delete(Long id, Long userId, boolean isAdmin) {
         withDankookService.delete(eatingAloneRepository, id, userId, isAdmin);
+    }
+
+    @Transactional
+    public void close(Long tradeId, Long userId) {
+        eatingAloneRepository.findById(tradeId).ifPresent(eatingAlone -> {
+            if (eatingAlone.getMasterUser().getId().equals(userId)) {
+                eatingAlone.close();
+            } else{
+                throw new NotGrantedException();
+            }
+        });
     }
 }

--- a/src/main/java/com/dku/council/domain/with_dankook/service/RoommateService.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/service/RoommateService.java
@@ -13,7 +13,6 @@ import com.dku.council.domain.with_dankook.model.entity.type.Roommate;
 import com.dku.council.domain.with_dankook.repository.RoomMateSurveyRepository;
 import com.dku.council.domain.with_dankook.repository.WithDankookUserRepository;
 import com.dku.council.domain.with_dankook.repository.with_dankook.RoommateRepository;
-import com.dku.council.domain.with_dankook.repository.with_dankook.WithDankookRepository;
 import com.dku.council.global.auth.role.UserRole;
 import com.dku.council.global.error.exception.NotGrantedException;
 import com.dku.council.global.error.exception.UserNotFoundException;
@@ -117,7 +116,7 @@ public class RoommateService {
         }
 
         if (targetUser.getParticipantStatus().equals(ParticipantStatus.WAITING)
-                && !withDankookUserRepository.findByUserIdCheckingValid(targetUserId)) {
+                && withDankookUserRepository.findByUserIdCheckingValid(roommateId, targetUserId).isEmpty()) {
             targetUser.changeStatusToValid();
             withDankookUserRepository.save(targetUser);
         } else {

--- a/src/main/java/com/dku/council/domain/with_dankook/service/StudyService.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/service/StudyService.java
@@ -8,6 +8,7 @@ import com.dku.council.domain.with_dankook.exception.InvalidMinStudentIdExceptio
 import com.dku.council.domain.with_dankook.exception.StudyCooltimeException;
 import com.dku.council.domain.with_dankook.exception.WithDankookNotFoundException;
 import com.dku.council.domain.with_dankook.model.dto.list.SummarizedStudyDto;
+import com.dku.council.domain.with_dankook.model.dto.list.SummarizedStudyPossibleReviewDto;
 import com.dku.council.domain.with_dankook.model.dto.request.RequestCreateStudyDto;
 import com.dku.council.domain.with_dankook.model.dto.response.ResponseSingleStudyDto;
 import com.dku.council.domain.with_dankook.model.entity.WithDankookUser;
@@ -23,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
@@ -31,7 +33,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -127,6 +132,22 @@ public class StudyService {
                         study,
                         withDankookUserService.recruitedCount(withDankookService.makeListDto(50, study).getId())
                 ));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<SummarizedStudyPossibleReviewDto> listMyPossibleReviewPosts(Long userId, Pageable pageable) {
+        List<SummarizedStudyPossibleReviewDto> list = studyRepository.findAllPossibleReviewPost(userId, pageable)
+                .map(study -> {
+                    SummarizedStudyPossibleReviewDto dto = new SummarizedStudyPossibleReviewDto(study, userId);
+                    if (!dto.getTargetUserList().isEmpty()) {
+                        return dto;
+                    } else {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .stream().collect(Collectors.toList());
+        return new PageImpl<>(list);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/dku/council/domain/with_dankook/service/WithDankookService.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/service/WithDankookService.java
@@ -213,18 +213,28 @@ public class WithDankookService<E extends WithDankook> {
     public void isPossibleCreateReview(Long withDankookId) {
         String withDankookType = withDankookRepository.findWithDankookType(withDankookId);
 
-        if (withDankookType.equals("Trade")) {
-            if (withDankookRepository.findWithClosedByIdToCreateReview(withDankookId) != 1) {
-                throw new InvalidStatusException();
-            }
-//        } else if (withDankookType.equals("Study") || withDankookType.equals("Dormitory")) {
-//            if (withDankookRepository.findWithClosedOrFullOrActiveByIdToCreateReview(withDankookId) != 1) {
-//                throw new InvalidStatusException();
-//            }
-        } else if (withDankookType.equals("BearEats") || withDankookType.equals("EatingAlong")) {
-            if (withDankookRepository.findWithClosedOrFullByIdToCreateReview(withDankookId) != 1) {
-                throw new InvalidStatusException();
-            }
+        switch (withDankookType) {
+            case "Trade":
+            case "Roommate":
+                if (withDankookRepository.findWithClosedByIdToCreateReview(withDankookId) != 1) {
+                    throw new InvalidStatusException();
+                }
+                break;
+            case "Study":
+                if (withDankookRepository.findWithClosedOrFullOrActiveEndTimeByIdToCreateReview(withDankookId) != 1) {
+                    throw new InvalidStatusException();
+                }
+                break;
+            case "EatingAlong":
+                if (withDankookRepository.findWithClosedOrFullByIdToCreateReview(withDankookId) != 1) {
+                    throw new InvalidStatusException();
+                }
+                break;
+            case "BearEats":
+                if (withDankookRepository.findWithClosedOrFullOrActiveDeliveryTimeByIdToCreateReview(withDankookId) != 1) {
+                    throw new InvalidStatusException();
+                }
+                break;
         }
     }
 }


### PR DESCRIPTION
### issue 번호

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
1. 단국 거래를 제외한 With-dankook 타입별, 사용자가 참여한 게시글 중 리뷰 작성이 가능한 게시글 목록 조회 기능 추가
2. 리뷰 생성 시, BearEats에 대한 리뷰 작성이 가능한 조건(ACTIVE 상태일 때, deliveryTime <= curTime) 추가
3. 구해줘! 룸메 코드에 대한 일부 로직 버그 수정
